### PR TITLE
Updated Workflow to Exclude PRs with 'skip_acceptance' Label

### DIFF
--- a/.github/workflows/post-merge-action.yml
+++ b/.github/workflows/post-merge-action.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   print_labels:
     name: Print PR labels (only for PRs merged into main with the acceptance label)
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && contains(github.event.pull_request.labels.*.name, 'acceptance')
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && !contains(github.event.pull_request.labels.*.name, 'skip_acceptance')
     runs-on: ubuntu-latest
     steps:
       - name: Print PR labels


### PR DESCRIPTION
# Description
This update modifies the GitHub Actions workflow to exclude PRs labeled with 'skip_acceptance' from a specific job, enhancing the automation process.

# Changes
- Changed condition to exclude PRs with 'skip_acceptance' label instead of only including those with 'acceptance'.