### PR TITLE
Enhanced Post-Merge Action Trigger Conditions

### DIFF
--- a/.github/workflows/post-merge-action.yml
+++ b/.github/workflows/post-merge-action.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types:
       - closed
+    paths:
+      - ".github/workflows/post-merge-action.yml"
 
 jobs:
   print_labels:


### PR DESCRIPTION
# Description
Refined the post-merge GitHub action to trigger only for specific path changes, enhancing workflow efficiency.

# Changes
- Added a `paths` filter to trigger the action only for changes in `.github/workflows/post-merge-action.yml`